### PR TITLE
Add support for HCIScanner to specify HCI device, for systems with mu…

### DIFF
--- a/blepp/blestatemachine.h
+++ b/blepp/blestatemachine.h
@@ -289,7 +289,6 @@ namespace BLEPP
 			void unexpected_error(const PDUErrorResponse&);
 			void fail(Disconnect);
 
-			void connect(const std::string& addresa, bool blocking);
 		public:
 
 
@@ -311,7 +310,7 @@ namespace BLEPP
 			
 			void connect_blocking(const std::string& addres);
 			void connect_nonblocking(const std::string& addres);
-
+			void connect(const std::string& addresa, bool blocking, bool pubaddr = true, std::string device = "");
 			void close();
 
 			int socket();

--- a/blepp/lescan.h
+++ b/blepp/lescan.h
@@ -171,7 +171,7 @@ namespace BLEPP
 
 		HCIScanner();
 		HCIScanner(bool start);
-		HCIScanner(bool start, FilterDuplicates duplicates, ScanType);
+		HCIScanner(bool start, FilterDuplicates duplicates, ScanType, std::string device="");
 
 
 		void start();

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -228,8 +228,7 @@ namespace BLEPP
 		//a PSM (wtf?) 
 		//  Protocol Service Multiplexer (WTF?)
 		//an address (of course)
-		//a CID (wtf) 
-		//  Channel ID (i.e. port number?)
+		//a CID(Channel ID) - See bluetooth 4.2 core spec for more info, section 2.1 CHANNEL IDENTIFIERS ATTRIBUTE PROTOCOL
 		//and an address type (wtf)
 		//Holy cargo cult, Batman!
 

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -34,6 +34,8 @@
 
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/l2cap.h>
+#include <bluetooth/hci.h>
+#include <bluetooth/hci_lib.h>
 using namespace std;
 
 
@@ -201,7 +203,7 @@ namespace BLEPP
 		connect(address, false);
 	}
 
-	void BLEGATTStateMachine::connect(const string& address, bool blocking)
+	void BLEGATTStateMachine::connect(const string& address, bool blocking, bool pubaddr, string device)
 	{
 		ENTER();
 
@@ -228,17 +230,35 @@ namespace BLEPP
 		//a PSM (wtf?) 
 		//  Protocol Service Multiplexer (WTF?)
 		//an address (of course)
-		//a CID(Channel ID) - See bluetooth 4.2 core spec for more info, section 2.1 CHANNEL IDENTIFIERS ATTRIBUTE PROTOCOL
-		//and an address type (wtf)
+		//a CID(Channel ID) - See bluetooth 4.2 core spec for more info
+		//  Section 2.1 CHANNEL IDENTIFIERS ATTRIBUTE PROTOCOL
+		//and an address type
+		//  See bluetooth 4.2 core spec for more info, section 15.1.1
+		//  Device will either have a registered "public" address, or a private "random" one that meets certain criteria
 		//Holy cargo cult, Batman!
 
 
 		sockaddr_l2 sba;
 		memset(&sba, 0, sizeof(sba));
-		sba.l2_bdaddr={{0,0,0,0,0,0}};
+		if (device == "") sba.l2_bdaddr={{0,0,0,0,0,0}}; //use default adapter
+		
+		else {
+			bdaddr_t btsrc_addr;
+			int dev_id = hci_devid(device.c_str()); //obtain device id from HCI device name
+			LOG(Debug, "dev_id = " << dev_id);
+			if (dev_id < 0) {
+				throw SocketConnectFailed("Error obtaining HCI device ID");
+			}	
+			hci_devba(dev_id, &btsrc_addr); 
+			bacpy(&sba.l2_bdaddr,&btsrc_addr); //lifted from bluez example, populate src sockaddr with address of desired device
+		}
+		
+		
+
+		
 		sba.l2_family=AF_BLUETOOTH;
 		sba.l2_cid = htobs(LE_ATT_CID);
-		sba.l2_bdaddr_type=BDADDR_LE_PUBLIC;
+		sba.l2_bdaddr_type = BDADDR_LE_PUBLIC;
 		log_fd(bind(sock, (sockaddr*)&sba , sizeof(sba)));
 
 		memset(&addr, 0, sizeof(addr));
@@ -247,9 +267,9 @@ namespace BLEPP
 		addr.l2_cid = htobs(LE_ATT_CID);
 
 
-		//Address type: Low Energy public
-		addr.l2_bdaddr_type=BDADDR_LE_PUBLIC;
-		
+		//Address type: Low Energy PUBLIC or RANDOM
+		if (pubaddr) addr.l2_bdaddr_type = BDADDR_LE_PUBLIC;
+		else addr.l2_bdaddr_type = BDADDR_LE_RANDOM;
 
 		if(log_l2cap_options(sock) == -1)
 		{

--- a/src/lescan.cc
+++ b/src/lescan.cc
@@ -116,7 +116,7 @@ namespace BLEPP
 	}
 
 
-	HCIScanner::HCIScanner(bool start_scan, FilterDuplicates filtering, ScanType st)
+	HCIScanner::HCIScanner(bool start_scan, FilterDuplicates filtering, ScanType st, string device)
 	{
 		if(filtering == FilterDuplicates::Hardware || filtering == FilterDuplicates::Both)
 			hardware_filtering = true;
@@ -130,9 +130,17 @@ namespace BLEPP
 
 		scan_type=st;
 
-		//Get a route to any(?) BTLE adapter (?)
-		//FIXME check errors
-		int	dev_id = hci_get_route(NULL);
+		int	dev_id = 0;
+		if (device == "") {
+			//Get a route to any(?) BTLE adapter (?)
+			dev_id = hci_get_route(NULL);
+		}
+		else {
+			dev_id = hci_devid(device.c_str());
+		}
+		if (dev_id < 0) {
+			throw HCIError("Error obtaining HCI device ID");
+		}
 		
 		//Open the device
 		//FIXME check errors


### PR DESCRIPTION
My computer has two BT adapters, one only is BT 2.0, the other 4.  The default route is BT2 for whatever reason, so this is needed.