### PR TITLE
added raw packet to advertisement, needed for beacons major and minor.

### DIFF
--- a/blepp/lescan.h
+++ b/blepp/lescan.h
@@ -85,7 +85,7 @@ namespace BLEPP
 		std::vector<std::vector<uint8_t>> manufacturer_specific_data;
 		std::vector<std::vector<uint8_t>> service_data;
 		std::vector<std::vector<uint8_t>> unparsed_data_with_types;
-
+		std::vector<std::vector<uint8_t>> raw_packet;
 	};
 
 	/// Class for scanning for BLE devices

--- a/src/lescan.cc
+++ b/src/lescan.cc
@@ -598,6 +598,7 @@ namespace BLEPP
 				rsp.address = address;
 				rsp.type = event_type;
 				rsp.rssi = rssi;
+				rsp.raw_packet.push_back({data.begin(), data.end()});
 
 				while(data.size() > 0)
 				{
@@ -609,6 +610,7 @@ namespace BLEPP
 					LOGVAR(Debug, length);
 
 					Span chunk = data.pop_front(length);
+
 					uint8_t type = chunk[0];
 					LOGVAR(Debug, type);
 


### PR DESCRIPTION
Parsing beacon advertisements were not complete as the major and minor could not be found anywhere. I have added the raw packet information into the AdvertisingResponse. 