### PR TITLE
support ATT MTU response

### DIFF
--- a/blepp/bledevice.h
+++ b/blepp/bledevice.h
@@ -58,6 +58,7 @@ namespace BLEPP
 		void send_handle_value_confirmation();
 		void send_write_command(std::uint16_t handle, const std::uint8_t* data, int length);
 		void send_write_command(std::uint16_t handle, std::uint16_t data);
+		void send_pdu(PDUResponse &pdu);
 		PDUResponse receive(std::uint8_t* buf, int max);
 		PDUResponse receive(std::vector<std::uint8_t>& v);
 	};

--- a/blepp/bledevice.h
+++ b/blepp/bledevice.h
@@ -58,7 +58,8 @@ namespace BLEPP
 		void send_handle_value_confirmation();
 		void send_write_command(std::uint16_t handle, const std::uint8_t* data, int length);
 		void send_write_command(std::uint16_t handle, std::uint16_t data);
-		void send_pdu(PDUResponse &pdu);
+		void process_att_mtu_request(PDUResponse &req_pdu);
+		void process_att_mtu_response(PDUResponse &resp_pdu);
 		PDUResponse receive(std::uint8_t* buf, int max);
 		PDUResponse receive(std::vector<std::uint8_t>& v);
 	};

--- a/src/bledevice.cc
+++ b/src/bledevice.cc
@@ -148,6 +148,11 @@ namespace BLEPP
 		send_write_command(handle, buf, 2);
 	}
 
+	void BLEDevice::send_pdu(PDUResponse &pdu)
+	{
+			int len = write(sock,pdu.data,pdu.length);
+			test(len, Write);
+	}
 
 	PDUResponse BLEDevice::receive(uint8_t* buf, int max)
 	{

--- a/src/bledevice.cc
+++ b/src/bledevice.cc
@@ -176,9 +176,9 @@ namespace BLEPP
 		// For performance, this could be raised if desired
 		if (my_final_mtu > my_current_mtu) //remote device's MTU is larger, increase local ATT buffer
 		{
-			buf.resize(req_mtu);
-			LOG(Debug,"Resized local MTU from " << my_current_mtu << " to " << req_mtu);
-			my_current_mtu = req_mtu;
+			buf.resize(my_final_mtu);
+			LOG(Debug,"Resized local MTU from " << my_current_mtu << " to " << my_final_mtu);
+			my_current_mtu = my_final_mtu;
 		}
 
 		int my_resp_pdu_len = enc_mtu_resp(my_current_mtu,my_resp_pdu,3);

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -559,22 +559,16 @@ namespace BLEPP
 				if(!n.notification())
 					dev.send_handle_value_confirmation();
 			}
-			//client is asking for MTU negotiation, ATTRIBUTE PROTOCOL 3.2.8, 3.4.2 MTU exchange of bluetooth core spec
+			//client is asking for MTU negotiation, VOL 3, PART F 3.4.2.1 Exchange MTU Request of bluetooth core spec
 			else if (r.type() == ATT_OP_MTU_REQ)
-			{ //TODO implement ATT buffer resize
-				uint8_t pdu[3];
-				uint16_t current_mtu = (uint16_t)dev.buf.size();
-				int minlen = enc_mtu_resp(current_mtu,pdu,3);
-				if (minlen > 0)
-				{
-					PDUResponse prsp(pdu,3);
-					dev.send_pdu(prsp);
-					LOG(Debug,"Sending MTU Resp len " << current_mtu);
-				}
-				else
-				{
-					LOG(Error,"Error generating MTU Response PDU");
-				}
+			{
+				dev.process_att_mtu_request(r);
+			}
+			//client is responding to our MTU request generated off their request
+			//VOL 3, PART F 3.4.2.2 Exchange MTU Request of bluetooth core spec
+			else if (r.type() == ATT_OP_MTU_RESP)
+			{
+				dev.process_att_mtu_response(r);
 			}
 			else if(r.type() == ATT_OP_ERROR && PDUErrorResponse(r).request_opcode() != last_request)
 			{

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -559,10 +559,18 @@ namespace BLEPP
 				if(!n.notification())
 					dev.send_handle_value_confirmation();
 			}
+			//client is asking for MTU negotiation, ATTRIBUTE PROTOCOL 3.2.8, 3.4.2 MTU exchange of bluetooth core spec
+			else if (r.type() == ATT_OP_MTU_REQ) { //TODO implement ATT buffer resize
+				uint8_t pdu[3];
+				uint16_t current_mtu = (uint16_t)dev.buf.size();
+				int minlen = enc_mtu_resp(current_mtu,pdu,3);
+				PDUResponse prsp(pdu,3);
+				dev.send_pdu(prsp);
+				LOG(Debug,"Sending MTU Resp len " << current_mtu);
+			}
 			else if(r.type() == ATT_OP_ERROR && PDUErrorResponse(r).request_opcode() != last_request)
 			{
 				PDUErrorResponse err(r);
-
 				std::string msg = string("Unexpected opcode in error. Expected ") + att_op2str(last_request) + " got "  + att_op2str(err.request_opcode());
 				LOG(Error, msg);
 				fail(Disconnect(Disconnect::Reason::UnexpectedError, Disconnect::NoErrorCode));

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -560,13 +560,21 @@ namespace BLEPP
 					dev.send_handle_value_confirmation();
 			}
 			//client is asking for MTU negotiation, ATTRIBUTE PROTOCOL 3.2.8, 3.4.2 MTU exchange of bluetooth core spec
-			else if (r.type() == ATT_OP_MTU_REQ) { //TODO implement ATT buffer resize
+			else if (r.type() == ATT_OP_MTU_REQ)
+			{ //TODO implement ATT buffer resize
 				uint8_t pdu[3];
 				uint16_t current_mtu = (uint16_t)dev.buf.size();
 				int minlen = enc_mtu_resp(current_mtu,pdu,3);
-				PDUResponse prsp(pdu,3);
-				dev.send_pdu(prsp);
-				LOG(Debug,"Sending MTU Resp len " << current_mtu);
+				if (minlen > 0)
+				{
+					PDUResponse prsp(pdu,3);
+					dev.send_pdu(prsp);
+					LOG(Debug,"Sending MTU Resp len " << current_mtu);
+				}
+				else
+				{
+					LOG(Error,"Error generating MTU Response PDU");
+				}
 			}
 			else if(r.type() == ATT_OP_ERROR && PDUErrorResponse(r).request_opcode() != last_request)
 			{


### PR DESCRIPTION
Got this pull-ready.  This OK?

Current behavior:  Library will crash.  See issue #31 

Change justification:  By spec, BT devices may request an MTU negotiation.  They may refuse anything but MTU responses after that.  

Validation:
hcidump shows MTU response packets being sent
> ACL data: handle 74 flags 0x02 dlen 7
    ATT: MTU req (0x02)
      client rx mtu 247
< HCI Command: LE Read Remote Used Features (0x08|0x0016) plen 2
  0000: 4a 00                                             J.
> HCI Event: Command Status (0x0f) plen 4
    LE Read Remote Used Features (0x08|0x0016) status 0x00 ncmd 1
> HCI Event: LE Meta Event (0x3e) plen 12
    LE Read Remote Used Features Complete
      status 0x00 handle 74
      Features: 0x01 0x00 0x00 0x00 0x00 0x00 0x00 0x00
< ACL data: handle 74 flags 0x00 dlen 7
    ATT: MTU resp (0x03)
      server rx mtu 23

Unrelated:
Did you intend for PDUResponse to be used for outbound packet generation too?
I see PDUResponse uses const pointers.  That can be dangerous, if source buffers that fed it go out of scope.  Working with sockets in the past, send() can also return < len if the send buffers are full.

Should PDUResponse's constructor be converted to a copy constructor, into an internal std::vector?
