### PR TITLE
Fix CMakeLists for usage as subdirectory in larger projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(EXAMPLES
     examples/lescan_simple.cc
     examples/temperature.cc)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules;${CMAKE_MODULE_PATH}")
 
 find_package(Bluez REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,13 +41,14 @@ find_package(Bluez REQUIRED)
 
 include_directories(${PROJECT_SOURCE_DIR} ${BLUEZ_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} SHARED ${SRC})
+target_link_libraries(${PROJECT_NAME} ${BLUEZ_LIBRARIES})
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 5)
 
 foreach (example_src ${EXAMPLES})
     get_filename_component(example_name ${example_src} NAME_WE)
 
     add_executable(${example_name} ${example_src})
-    target_link_libraries(${example_name} ${PROJECT_NAME} ${BLUEZ_LIBRARIES})
+    target_link_libraries(${example_name} ${PROJECT_NAME})
     set_target_properties(${example_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY examples)
 endforeach()
 


### PR DESCRIPTION
When included via `add_subdirectory(libblepp)`, the `${CMAKE_SOURCE_DIR}` variable refers to the root project, not libblepp. Also fixes clobbering anything else that was previously in the path.