### PR TITLE
Submodule support & modern setting of CXX_STANDARD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ set(EXAMPLES
     examples/lescan_simple.cc
     examples/temperature.cc)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 find_package(Bluez REQUIRED)
 
@@ -53,3 +53,4 @@ endforeach()
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)
 install(DIRECTORY blepp DESTINATION include)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
 cmake_minimum_required(VERSION 3.4)
 project(ble++)
 
-set(CMAKE_CXX_STANDARD 11)
-
 set(HEADERS
     blepp/bledevice.h
     blepp/logging.h
@@ -41,14 +39,20 @@ find_package(Bluez REQUIRED)
 
 include_directories(${PROJECT_SOURCE_DIR} ${BLUEZ_INCLUDE_DIRS})
 add_library(${PROJECT_NAME} SHARED ${SRC})
-set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 5)
+set_target_properties(${PROJECT_NAME} PROPERTIES 
+    CXX_STANDARD 11
+    CMAKE_CXX_STANDARD_REQUIRED YES
+    SOVERSION 5)
 
 foreach (example_src ${EXAMPLES})
     get_filename_component(example_name ${example_src} NAME_WE)
 
     add_executable(${example_name} ${example_src})
     target_link_libraries(${example_name} ${PROJECT_NAME} ${BLUEZ_LIBRARIES})
-    set_target_properties(${example_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY examples)
+    set_target_properties(${example_name} PROPERTIES 
+        CXX_STANDARD 11
+        CMAKE_CXX_STANDARD_REQUIRED YES    
+        RUNTIME_OUTPUT_DIRECTORY examples)
 endforeach()
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)


### PR DESCRIPTION
Hi,

This pull request fixes the CMake file for support in a submodule project (CMAKE_SOURCE_DIR is the wrong path as a submodule, fixed with PROJECT_SOURCE_DIR).
Also, better scope for CXX_STANDARD.
