### PR TITLE
Add API to resize the buffer of the BLEDevice

### DIFF
--- a/blepp/bledevice.h
+++ b/blepp/bledevice.h
@@ -62,6 +62,7 @@ namespace BLEPP
 		void process_att_mtu_response(PDUResponse &resp_pdu);
 		PDUResponse receive(std::uint8_t* buf, int max);
 		PDUResponse receive(std::vector<std::uint8_t>& v);
+		void set_buffer_size(size_t buffer_size);
 	};
 
 }

--- a/blepp/blestatemachine.h
+++ b/blepp/blestatemachine.h
@@ -360,6 +360,8 @@ namespace BLEPP
 
 
 			void setup_standard_scan(std::function<void()>& cb);
+
+			void set_device_buffer_size(size_t size);
 	};
 
 

--- a/src/bledevice.cc
+++ b/src/bledevice.cc
@@ -322,4 +322,8 @@ namespace BLEPP
 		buf.resize(ATT_DEFAULT_MTU);
 	}
 
+	void BLEDevice::set_buffer_size(size_t buffer_size) {
+		buf.resize(buffer_size);
+	}
+
 }

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -922,4 +922,8 @@ namespace BLEPP
 		};
 	}
 
+	void BLEGATTStateMachine::set_device_buffer_size(size_t size) {
+		dev.set_buffer_size(size);
+	}
+
 }


### PR DESCRIPTION
If the device sends packets that are larger than 128 bytes, the extra
bytes are dropped. This adds an API to allow for clients to resize the
buffer to obtain the full message.