### PR TITLE
Add resize also to BLEStateMachine's buffer to match the device buffer size

### DIFF
--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -923,6 +923,7 @@ namespace BLEPP
 	}
 
 	void BLEGATTStateMachine::set_device_buffer_size(size_t size) {
+		buf.resize(size);
 		dev.set_buffer_size(size);
 	}
 


### PR DESCRIPTION
Forgot to include this in the previous change, sorry