### PR TITLE
Catch polymorphic errors by reference

### DIFF
--- a/examples/bluetooth.cc
+++ b/examples/bluetooth.cc
@@ -282,11 +282,11 @@ int main(int argc, char **argv)
 			}
 		}
 	}
-	catch(std::runtime_error e)
+	catch(std::runtime_error& e)
 	{
 		cerr << "Something's stopping bluetooth working: " << e.what() << endl;
 	}
-	catch(std::logic_error e)
+	catch(std::logic_error& e)
 	{
 		cerr << "Oops, someone fouled up: " << e.what() << endl;
 	}

--- a/examples/write.cc
+++ b/examples/write.cc
@@ -81,11 +81,11 @@ int main(int argc, char **argv)
 			gatt.read_and_process_next();
 		}
 	}
-	catch(std::runtime_error e)
+	catch(std::runtime_error& e)
 	{
 		cerr << "Something's stopping bluetooth working: " << e.what() << endl;
 	}
-	catch(std::logic_error e)
+	catch(std::logic_error& e)
 	{
 		cerr << "Oops, someone fouled up: " << e.what() << endl;
 	}

--- a/src/lescan.cc
+++ b/src/lescan.cc
@@ -274,7 +274,7 @@ namespace BLEPP
 		{
 			stop();
 		}
-		catch(IOError)
+		catch(IOError&)
 		{
 		}
 	}
@@ -691,7 +691,7 @@ namespace BLEPP
 
 
 			}
-			catch(out_of_range r)
+			catch(out_of_range& r)
 			{
 				LOG(LogLevels::Error, "Corrupted data sent by device " << address);
 			}


### PR DESCRIPTION
Errors of polymorphic types (such as `std::runtime_error`) should be caught by reference to prevent object slicing (especially since `what()` is virtual). I'm not sure whether there's any possibility of subclasses of, say, `std::runtime_error` being thrown, but it doesn't hurt to catch by reference and at the very least this change silences some warnings.