### PR TITLE
Configure buffersize

### DIFF
--- a/blepp/att_pdu.h
+++ b/blepp/att_pdu.h
@@ -285,7 +285,7 @@ namespace BLEPP
 			{
 				type_check(ATT_OP_FIND_INFO_RESP);
 				if( (length-2) % element_size())
-					error<std::runtime_error>("Invalid packet length for PDUReadGroupByTypeResponse");
+					error<std::runtime_error>("Invalid packet length for PDUFindInformationResponse");
 			}
 
 			bool is_16_bit() const

--- a/blepp/blestatemachine.h
+++ b/blepp/blestatemachine.h
@@ -329,7 +329,7 @@ namespace BLEPP
 			std::function<void(Characteristic&, const PDUReadResponse&)> cb_read;
 
 
-			BLEGATTStateMachine();
+			BLEGATTStateMachine(size_t bufsize=128);
 			~BLEGATTStateMachine();
 
 			

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -191,12 +191,12 @@ namespace BLEPP
 		close_and_cleanup();
 	}
 
-	BLEGATTStateMachine::BLEGATTStateMachine()
+	BLEGATTStateMachine::BLEGATTStateMachine(size_t bufsize)
 	:dev(sock)
 	{
 		ENTER();
 		close_and_cleanup();
-		buf.resize(128);
+		buf.resize(bufsize);
 	}
 
 	void BLEGATTStateMachine::connect_blocking(const string& address)


### PR DESCRIPTION
I encountered a device (Xsens DOT), that returned a 160-byte message and needed a bigger buffer for the state machine. I made the buffer size configurable, with the current (128 byte) default.
In the debugging process, I also found a misnamed error message