### PR TITLE
CMake Pckage Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,26 @@
 cmake_minimum_required(VERSION 3.4)
 project(ble++)
+set(PROJECT_VERSION "1.2")
+set(PROJECT_DESCRIPTION "Bluetooth LE interface for C++")
+
+set(CMAKE_CXX_STANDARD 11)
+set(TARGET1_NAME ${PROJECT_NAME} CACHE INTERNAL "")
+
+set(default_build_type "Release")
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+            STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+            "Debug" "Release")
+endif()
+
+option(WITH_EXAMPLES "Build examples" OFF)
+
+include(GNUInstallDirs)
+
+#----------------------- LIBRARY --------------------------------
 
 set(HEADERS
     blepp/bledevice.h
@@ -26,13 +47,6 @@ set(SRC
     src/lescan.cc
     ${HEADERS})
 
-set(EXAMPLES
-    examples/lescan.cc
-    examples/blelogger.cc
-    examples/bluetooth.cc
-    examples/lescan_simple.cc
-    examples/temperature.cc)
-
 LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 find_package(Bluez REQUIRED)
@@ -46,19 +60,38 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
     CMAKE_CXX_STANDARD_REQUIRED YES
     SOVERSION 5)
 
+#----------------------- EXAMPLES --------------------------------
+if(WITH_EXAMPLES)
+    set(EXAMPLES
+            examples/lescan.cc
+            examples/blelogger.cc
+            examples/bluetooth.cc
+            examples/lescan_simple.cc
+            examples/temperature.cc)
 
-foreach (example_src ${EXAMPLES})
-    get_filename_component(example_name ${example_src} NAME_WE)
+    foreach (example_src ${EXAMPLES})
+        get_filename_component(example_name ${example_src} NAME_WE)
 
-    add_executable(${example_name} ${example_src})
+        add_executable(${example_name} ${example_src})
+        target_link_libraries(${example_name} ${BLUEZ_LIBRARIES} ${PROJECT_NAME})
 
-    set_target_properties(${example_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY examples)
-    set_target_properties(${example_name} PROPERTIES 
-        CXX_STANDARD 11
-        CMAKE_CXX_STANDARD_REQUIRED YES    
-        RUNTIME_OUTPUT_DIRECTORY examples)
-endforeach()
+        set_target_properties(${example_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY examples)
+        set_target_properties(${example_name} PROPERTIES
+            CXX_STANDARD 11
+            CMAKE_CXX_STANDARD_REQUIRED YES
+            RUNTIME_OUTPUT_DIRECTORY examples)
+    endforeach()
+endif()
 
-install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION lib)
-install(DIRECTORY blepp DESTINATION include)
+#----------------------- PKG CONFIGURATION --------------------------------
+message(STATUS "Package Ble++ for ${CMAKE_BUILD_TYPE} version ${PROJECT_VERSION}")
+set(TARGET1 ${TARGET1_NAME})
+set(PackagingTemplatesDir "${CMAKE_CURRENT_SOURCE_DIR}/packaging")
+# Generate pkg-config file
+configure_file("${PackagingTemplatesDir}/libblepp.pc.in" ${CMAKE_CURRENT_BINARY_DIR}/libblepp.pc @ONLY)
+
+#----------------------- INSTALL --------------------------------
+install(TARGETS ${TARGET1_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(DIRECTORY blepp DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libblepp.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,44 @@
-libble++
----------
+# libble++
 
 Implementation of Bluetooth Low Energy functions in modern C++, without
 the BlueZ DBUS API.
 
-Includes:
+### Includes
 * Scanning for bluetooth packets
-
 * Implementation of the GATT profile and ATT protocol
-
 * Lots of comments, complete with references to the specific part of
   the Bluetooth 4.0 standard.
-
 * Example programs
 
-Design:
-
+### Design
 Clean, modern C++ with callbacks. Feed it with lambdas (or whatever you like)
 to perform an event happens. Access provided to the raw socket FD, so 
 you can use select(), poll() or blocking IO.
 
-
-
-The example programs are:
-
+### The example programs
 * lescan_simple: Simplest possible program for scanning for devices. Only 2 non boilerplate lines.
-
 * lescan: A "proper" scanning program that cleans up properly. It's got the same 2 lines of BLE related code and a bit of pretty standard unix for dealing with non blocking I/O and signals.
-
 * temperature: A program for logging temperature values from a device providing a standard temperature characteristic. Very short to indicate the usave, but not much error checking.
 
 
-Building the library
---------------------
-
+### Building the library
 There are currently autoconf (./configure) and CMake options. It's not
-a complex library to build, so either option should work fine.
+a complex library to build, so either option should work fine.  
+Autoconf:
+```
+./configure  
+make
+```  
+CMake:
+```
+mkdir build && cd build
+cmake ..
+make install
+```
+CMake with examples:  
+Examples will be in ```build/examples```
+```
+mkdir build && cd build
+cmake -DWITH_EXAMPLES=ON ..
+make install
+```

--- a/packaging/libblepp.pc.in
+++ b/packaging/libblepp.pc.in
@@ -1,0 +1,8 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@/blepp
+libdir=${prefix}/lib
+Name: libble++
+Description: @PROJECT_DESCRIPTION@
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}
+Libs: -L${libdir} -l@TARGET1@


### PR DESCRIPTION
This PR changes cmake build to make the examples optional and generate and install the pkg-config file. It also changes the README to markdown with better formatting and an updated build section.