### PR TITLE
Refactor code to remove 'using namespace std'

### DIFF
--- a/src/att_pdu.cc
+++ b/src/att_pdu.cc
@@ -24,45 +24,42 @@
 #include <blepp/att_pdu.h>
 #include <blepp/pretty_printers.h>
 
-using namespace std;
-
-
 void BLEPP::pretty_print(const PDUResponse& pdu)
 {
 	if(log_level >= Debug)
 	{
-		cerr << "debug: ---PDU packet ---\n";
-		cerr << "debug: " << to_hex(pdu.data, pdu.length) << endl;
-		cerr << "debug: " << to_str(pdu.data, pdu.length) << endl;
-		cerr << "debug: Packet type: " << to_hex(pdu.type()) << " " << att_op2str(pdu.type()) << endl;
+		std::cerr << "debug: ---PDU packet ---\n";
+		std::cerr << "debug: " << to_hex(pdu.data, pdu.length) << std::endl;
+		std::cerr << "debug: " << to_str(pdu.data, pdu.length) << std::endl;
+		std::cerr << "debug: Packet type: " << to_hex(pdu.type()) << " " << att_op2str(pdu.type()) << std::endl;
 		
 		if(pdu.type() == ATT_OP_ERROR)
-			cerr << "debug: " << PDUErrorResponse(pdu).error_str() << " in response to " <<  att_op2str(PDUErrorResponse(pdu).request_opcode()) << " on handle " + to_hex(PDUErrorResponse(pdu).handle()) << endl;
+			std::cerr << "debug: " << PDUErrorResponse(pdu).error_str() << " in response to " <<  att_op2str(PDUErrorResponse(pdu).request_opcode()) << " on handle " + to_hex(PDUErrorResponse(pdu).handle()) << std::endl;
 		else if(pdu.type() == ATT_OP_READ_BY_TYPE_RESP)
 		{
 			PDUReadByTypeResponse p(pdu);
 
-			cerr << "debug: elements = " << p.num_elements() << endl;
-			cerr << "debug: value size = " << p.value_size() << endl;
+			std::cerr << "debug: elements = " << p.num_elements() << std::endl;
+			std::cerr << "debug: value size = " << p.value_size() << std::endl;
 
 			for(int i=0; i < p.num_elements(); i++)
 			{
-				cerr << "debug: " << to_hex(p.handle(i)) << " ";
+				std::cerr << "debug: " << to_hex(p.handle(i)) << " ";
 				if(p.value_size() != 2)
-					cerr << "-->" << to_str(p.value(i)) << "<--" << endl;
+					std::cerr << "-->" << to_str(p.value(i)) << "<--" << std::endl;
 				else
-					cerr << to_hex(p.value_uint16(i)) << endl;
+					std::cerr << to_hex(p.value_uint16(i)) << std::endl;
 			}
 
 		}
 		else if(pdu.type() == ATT_OP_READ_BY_GROUP_RESP)
 		{
 			PDUReadGroupByTypeResponse p(pdu);
-			cerr << "debug: elements = " << p.num_elements() << endl;
-			cerr << "debug: value size = " << p.value_size() << endl;
+			std::cerr << "debug: elements = " << p.num_elements() << std::endl;
+			std::cerr << "debug: value size = " << p.value_size() << std::endl;
 
 			for(int i=0; i < p.num_elements(); i++)
-				cerr << "debug: " <<  "[ " << to_hex(p.start_handle(i)) << ", " << to_hex(p.end_handle(i)) << ") :" << to_str(p.value(i)) << endl;
+				std::cerr << "debug: " <<  "[ " << to_hex(p.start_handle(i)) << ", " << to_hex(p.end_handle(i)) << ") :" << to_str(p.value(i)) << std::endl;
 		}
 		else if(pdu.type() == ATT_OP_WRITE_RESP)
 		{
@@ -70,15 +67,15 @@ void BLEPP::pretty_print(const PDUResponse& pdu)
 		else if(pdu.type() == ATT_OP_HANDLE_NOTIFY || pdu.type() == ATT_OP_HANDLE_IND)
 		{
 			PDUNotificationOrIndication p(pdu);
-			cerr << "debug: handle = " << p.handle() << endl;
-			cerr << "debug: data = " << to_hex(p.value().first, p.value().second - p.value().first) << endl;
-			cerr << "debug: data = " << to_str(p.value().first, p.value().second - p.value().first) << endl;
+			std::cerr << "debug: handle = " << p.handle() << std::endl;
+			std::cerr << "debug: data = " << to_hex(p.value().first, p.value().second - p.value().first) << std::endl;
+			std::cerr << "debug: data = " << to_str(p.value().first, p.value().second - p.value().first) << std::endl;
 
 		}
 		else
-			cerr << "debug: --no pretty printer available--\n";
+			std::cerr << "debug: --no pretty printer available--\n";
 		
-		cerr << "debug:\n";
+		std::cerr << "debug:\n";
 	}
 };
 

--- a/src/bledevice.cc
+++ b/src/bledevice.cc
@@ -31,8 +31,6 @@
 
 #include <unistd.h>
 
-using namespace std;
-
 namespace BLEPP
 {
 
@@ -63,7 +61,7 @@ namespace BLEPP
 	void BLEDevice::test_pdu(int len)
 	{
 		if(len == 0)
-			throw logic_error("Error constructing packet");
+			throw std::logic_error("Error constructing packet");
 	}
 
 	class Read{};
@@ -222,7 +220,7 @@ namespace BLEPP
 		return PDUResponse(buf, len);
 	}
 
-	PDUResponse BLEDevice::receive(vector<uint8_t>& v)
+	PDUResponse BLEDevice::receive(std::vector<uint8_t>& v)
 	{
 		return receive(v.data(), v.size());
 	}

--- a/src/blestatemachine.cc
+++ b/src/blestatemachine.cc
@@ -36,9 +36,6 @@
 #include <bluetooth/l2cap.h>
 #include <bluetooth/hci.h>
 #include <bluetooth/hci_lib.h>
-using namespace std;
-
-
 
 #define log_fd(X) log_fd_(X, __LINE__, __FILE__)
 
@@ -77,7 +74,7 @@ namespace BLEPP
 
 	const ServiceInfo* lookup_service_by_UUID(const UUID& uuid)
 	{
-		static vector<ServiceInfo> vec;
+		static std::vector<ServiceInfo> vec;
 
 		if(vec.size() == 0)
 		{
@@ -199,18 +196,18 @@ namespace BLEPP
 		buf.resize(128);
 	}
 
-	void BLEGATTStateMachine::connect_blocking(const string& address)
+	void BLEGATTStateMachine::connect_blocking(const std::string& address)
 	{
 		connect(address, true);
 	}
 
 
-	void BLEGATTStateMachine::connect_nonblocking(const string& address)
+	void BLEGATTStateMachine::connect_nonblocking(const std::string& address)
 	{
 		connect(address, false);
 	}
 
-	void BLEGATTStateMachine::connect(const string& address, bool blocking, bool pubaddr, string device)
+	void BLEGATTStateMachine::connect(const std::string& address, bool blocking, bool pubaddr, std::string device)
 	{
 		ENTER();
 
@@ -392,7 +389,7 @@ namespace BLEPP
 	void BLEGATTStateMachine::read_primary_services()
 	{
 		if(state != Idle)
-			throw logic_error("Error trying to issue command mid state");
+			throw std::logic_error("Error trying to issue command mid state");
 		state = ReadingPrimaryService;
 		next_handle_to_read=1;
 		state_machine_write();
@@ -401,7 +398,7 @@ namespace BLEPP
 	void BLEGATTStateMachine::find_all_characteristics()
 	{
 		if(state != Idle)
-			throw logic_error("Error trying to issue command mid state");
+			throw std::logic_error("Error trying to issue command mid state");
 		state = FindAllCharacteristics;
 		next_handle_to_read=1;
 		state_machine_write();
@@ -410,7 +407,7 @@ namespace BLEPP
 	void BLEGATTStateMachine::get_client_characteristic_configuration()
 	{
 		if(state != Idle)
-			throw logic_error("Error trying to issue command mid state");
+			throw std::logic_error("Error trying to issue command mid state");
 		state = GetClientCharaceristicConfiguration;
 		next_handle_to_read=1;
 		state_machine_write();
@@ -421,12 +418,12 @@ namespace BLEPP
 		LOG(Trace, "BLEGATTStateMachine::enable_indications(Characteristic&)");
 
 		if(state != Idle)
-			throw logic_error("Error trying to issue command mid state");
+			throw std::logic_error("Error trying to issue command mid state");
 		
 		if(!c.indicate && indicate)
-			throw logic_error("Error: this is not indicateable");
+			throw std::logic_error("Error: this is not indicateable");
 		if(!c.notify && notify)
-			throw logic_error("Error: this is not notifiable");
+			throw std::logic_error("Error: this is not notifiable");
 
 		//FIXME: check for CCC
 		c.ccc_last_known_value = notify | (indicate << 1);
@@ -466,7 +463,7 @@ namespace BLEPP
 	void BLEGATTStateMachine::unexpected_error(const PDUErrorResponse& r)
 	{
 		PDUErrorResponse err(r);
-		string msg = string("Received unexpected error:") + att_ecode2str(err.error_code());
+		std::string msg = std::string("Received unexpected error:") + att_ecode2str(err.error_code());
 		LOG(Error, msg);
 		fail(Disconnect(Disconnect::Reason::UnexpectedError, Disconnect::NoErrorCode));
 	}
@@ -522,7 +519,7 @@ namespace BLEPP
 		ENTER();
 		//This is always an error
 		if(state == Connecting)
-			throw logic_error("Trying to read socket while connecting");
+			throw std::logic_error("Trying to read socket while connecting");
 
 
 		if(state == Disconnected)
@@ -574,13 +571,13 @@ namespace BLEPP
 			else if(r.type() == ATT_OP_ERROR && PDUErrorResponse(r).request_opcode() != last_request)
 			{
 				PDUErrorResponse err(r);
-				std::string msg = string("Unexpected opcode in error. Expected ") + att_op2str(last_request) + " got "  + att_op2str(err.request_opcode());
+				std::string msg = std::string("Unexpected opcode in error. Expected ") + att_op2str(last_request) + " got "  + att_op2str(err.request_opcode());
 				LOG(Error, msg);
 				fail(Disconnect(Disconnect::Reason::UnexpectedError, Disconnect::NoErrorCode));
 			}
 			else if(r.type() != ATT_OP_ERROR && r.type() != last_request + 1)
 			{
-				string msg = string("Unexpected response. Expected ") + att_op2str(last_request+1) + " got "  + att_op2str(r.type());
+				std::string msg = std::string("Unexpected response. Expected ") + att_op2str(last_request+1) + " got "  + att_op2str(r.type());
 				LOG(Error, msg);
 				fail(Disconnect(Disconnect::Reason::UnexpectedResponse, Disconnect::NoErrorCode));
 			}
@@ -794,7 +791,7 @@ namespace BLEPP
 	void BLEGATTStateMachine::send_read_request(uint16_t handle)
 	{
 		if(state != Idle)
-			throw logic_error("Error trying to issue command mid state");
+			throw std::logic_error("Error trying to issue command mid state");
 		dev.send_read_request(handle);
 		read_req_handle = handle;
 		state = AwaitingReadResponse;
@@ -809,7 +806,7 @@ namespace BLEPP
 	void BLEGATTStateMachine::send_write_request(uint16_t handle, const uint8_t* data, int length)
 	{
 		if(state != Idle)
-			throw logic_error("Error trying to issue command mid state");
+			throw std::logic_error("Error trying to issue command mid state");
 		dev.send_write_request(handle, data, length);
 		state = AwaitingWriteResponse;
 		state_machine_write();
@@ -823,7 +820,7 @@ namespace BLEPP
 	void BLEGATTStateMachine::send_write_command(uint16_t handle, const uint8_t* data, int length)
 	{
 		if(state != Idle)
-			throw logic_error("Error trying to issue command mid state");
+			throw std::logic_error("Error trying to issue command mid state");
 		dev.send_write_command(handle, data, length);
 	}
 
@@ -843,53 +840,53 @@ namespace BLEPP
 	void pretty_print_tree(const BLEGATTStateMachine& s)
 	{
 
-		cout << "Primary services:\n";
+		std::cout << "Primary services:\n";
 		for(auto& service: s.primary_services)
 		{
-			cout << "Start: " << to_hex(service.start_handle);
-			cout << " End:  " << to_hex(service.end_handle);
-			cout << " UUID: " << to_str(service.uuid) << endl;
+			std::cout << "Start: " << to_hex(service.start_handle);
+			std::cout << " End:  " << to_hex(service.end_handle);
+			std::cout << " UUID: " << to_str(service.uuid) << std::endl;
 			const ServiceInfo* s = lookup_service_by_UUID(UUID::from(service.uuid));
 			if(s)
-				cout << "  " << s->id << ": " << s->name << endl;
+				std::cout << "  " << s->id << ": " << s->name << std::endl;
 			else
-				cout << "  Unknown\n";
+				std::cout << "  Unknown\n";
 
 
 			for(auto& characteristic: service.characteristics)
 			{
-				cout  << "  Characteristic: " << to_str(characteristic.uuid) << endl;
-				cout  << "   Start: " << to_hex(characteristic.first_handle) << "  End: " << to_hex(characteristic.last_handle) << endl;
+				std::cout  << "  Characteristic: " << to_str(characteristic.uuid) << std::endl;
+				std::cout  << "   Start: " << to_hex(characteristic.first_handle) << "  End: " << to_hex(characteristic.last_handle) << std::endl;
 
-				cout << "   Flags: ";
+				std::cout << "   Flags: ";
 				if(characteristic.broadcast)
-					cout << "Broadcast ";
+					std::cout << "Broadcast ";
 				if(characteristic.read)
-					cout << "Read ";
+					std::cout << "Read ";
 				if(characteristic.write_without_response)
-					cout << "Write (without response) ";
+					std::cout << "Write (without response) ";
 				if(characteristic.write)
-					cout << "Write ";
+					std::cout << "Write ";
 				if(characteristic.notify)
-					cout << "Notify ";
+					std::cout << "Notify ";
 				if(characteristic.indicate)
-					cout << "Indicate ";
+					std::cout << "Indicate ";
 				if(characteristic.authenticated_write)
-					cout << "Authenticated signed writes ";
+					std::cout << "Authenticated signed writes ";
 				if(characteristic.extended)
-					cout << "Extended properties ";
-				cout  << endl;
+					std::cout << "Extended properties ";
+				std::cout  << std::endl;
 
-				cout << "   Value at handle: " << characteristic.value_handle << endl;
+				std::cout << "   Value at handle: " << characteristic.value_handle << std::endl;
 
 				if(characteristic.client_characteric_configuration_handle != 0)
-					cout << "   CCC: (" << to_hex(characteristic.client_characteric_configuration_handle) << ") " << to_hex(characteristic.ccc_last_known_value) << endl;
+					std::cout << "   CCC: (" << to_hex(characteristic.client_characteric_configuration_handle) << ") " << to_hex(characteristic.ccc_last_known_value) << std::endl;
 
-				cout << endl;
+				std::cout << std::endl;
 
 			}
 
-			cout << endl;
+			std::cout << std::endl;
 		}
 	}
 

--- a/src/float.cc
+++ b/src/float.cc
@@ -1,8 +1,6 @@
 #include <blepp/float.h>
 #include <cmath>
 
-using namespace std;
-
 namespace BLEPP
 {
 

--- a/src/pretty_printers.cc
+++ b/src/pretty_printers.cc
@@ -23,22 +23,21 @@
 
 #include <sstream>
 #include <iomanip>
-using namespace std;
 
 namespace BLEPP
 {
 
 	std::string to_hex(const std::uint16_t& u)
 	{
-		stringstream os;
-		os << setw(4) << setfill('0') << hex << u;
+        std::stringstream os;
+		os << std::setw(4) << std::setfill('0') << std::hex << u;
 		return os.str();
 	}
 
 	std::string to_hex(const std::uint8_t& u)
 	{
-		stringstream os;
-		os << setw(2) << setfill('0') << hex << (int)u;
+        std::stringstream os;
+		os << std::setw(2) << std::setfill('0') << std::hex << (int)u;
 		return os.str();
 	}
 
@@ -71,38 +70,38 @@ namespace BLEPP
 
 	std::string to_hex(const std::uint8_t* d, int l)
 	{
-		stringstream os;
+        std::stringstream os;
 		for(int i=0; i < l; i++)
 			os << to_hex(d[i]) << " ";
 		return os.str();
 	}
-	std::string to_hex(pair<const std::uint8_t*, int> d)
+	std::string to_hex(std::pair<const std::uint8_t*, int> d)
 	{
 		return to_hex(d.first, d.second);
 	}
 
-	std::string to_hex(const vector<std::uint8_t>& v)
+	std::string to_hex(const std::vector<std::uint8_t>& v)
 	{
 		return to_hex(v.data(), v.size());
 	}
 
 	std::string to_str(const std::uint8_t* d, int l)
 	{
-		stringstream os;
+		std::stringstream os;
 		for(int i=0; i < l; i++)
 			os << to_str(d[i]);
 		return os.str();
 	}
-	std::string to_str(pair<const std::uint8_t*, int> d)
+	std::string to_str(std::pair<const std::uint8_t*, int> d)
 	{
 		return to_str(d.first, d.second);
 	}
-	std::string to_str(pair<const std::uint8_t*, const std::uint8_t*> d)
+	std::string to_str(std::pair<const std::uint8_t*, const std::uint8_t*> d)
 	{
 		return to_str(d.first, d.second - d.first);
 	}
 
-	std::string to_str(const vector<std::uint8_t>& v)
+	std::string to_str(const std::vector<std::uint8_t>& v)
 	{
 		return to_str(v.data(), v.size());
 	}

--- a/tests/test_scan.cc
+++ b/tests/test_scan.cc
@@ -8,26 +8,25 @@
 
 
 using namespace BLEPP;
-using namespace std;
 
 #define check(X) do{\
 if(!(X))\
 {\
-	cerr << "Test failed on line " << __LINE__ << ": " << #X << endl;\
+	std::cerr << "Test failed on line " << __LINE__ << ": " << #X << std::endl;\
 	exit(1);\
 }}while(0)
 
-vector<uint8_t> to_data(const string& ss)
+std::vector<uint8_t> to_data(const std::string& ss)
 {
-	istringstream s(ss);
+    std::istringstream s(ss);
 
 	//Format is > 04 3E ...
 
-	string tmp;
+	std::string tmp;
 	s >> tmp;
-	s>>hex;
+	s>>std::hex;
 
-	vector<uint8_t> ret;
+	std::vector<uint8_t> ret;
 
 	for(;;)
 	{
@@ -91,7 +90,7 @@ device: hci0 snap_len: 1500 filter: 0xffffffffffffffff
 	check(!r.flags);
 
 	r = HCIScanner::parse_packet(to_data("> 04 3E 17 02 01 00 01 0B 57 16 21 76 7C 0B 02 01 1A 07 FF 4C 00 10 02 0A 00 BC")).back();
-	vector<uint8_t> vendor_data_1 = {0x4c, 0x00, 0x10, 0x02, 0x0a, 0x00};
+	std::vector<uint8_t> vendor_data_1 = {0x4c, 0x00, 0x10, 0x02, 0x0a, 0x00};
 	check(r.UUIDs.size() == 0);
 	check(r.service_data.empty());
 	check(r.manufacturer_specific_data.size() == 1);


### PR DESCRIPTION
This PR refactors the code to not use 'using namespace std' as doing so can cause some unwanted effects.
While it is very common to use 'using namespace std' I have found that it can cause some headaches when including libraries that use 'using namespace std'.
* https://www.geeksforgeeks.org/using-namespace-std-considered-bad-practice/
* https://stackoverflow.com/questions/1452721/why-is-using-namespace-std-considered-bad-practice