### PR TITLE
Replace boost::optional with std::optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(ble++)
 set(PROJECT_VERSION "1.2")
 set(PROJECT_DESCRIPTION "Bluetooth LE interface for C++")
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(TARGET1_NAME ${PROJECT_NAME} CACHE INTERNAL "")
 
 set(default_build_type "Release")
@@ -56,7 +56,7 @@ add_library(${PROJECT_NAME} SHARED ${SRC})
 
 target_link_libraries(${PROJECT_NAME} ${BLUEZ_LIBRARIES})
 set_target_properties(${PROJECT_NAME} PROPERTIES 
-    CXX_STANDARD 11
+    CXX_STANDARD 17
     CMAKE_CXX_STANDARD_REQUIRED YES
     SOVERSION 5)
 
@@ -77,7 +77,7 @@ if(WITH_EXAMPLES)
 
         set_target_properties(${example_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY examples)
         set_target_properties(${example_name} PROPERTIES
-            CXX_STANDARD 11
+            CXX_STANDARD 17
             CMAKE_CXX_STANDARD_REQUIRED YES
             RUNTIME_OUTPUT_DIRECTORY examples)
     endforeach()

--- a/blepp/lescan.h
+++ b/blepp/lescan.h
@@ -30,9 +30,10 @@
 #include <stdexcept>
 #include <cstdint>
 #include <set>
-#include <boost/optional.hpp>
+#include <optional>
 #include <blepp/blestatemachine.h> //for UUID. FIXME mofo
 #include <bluetooth/hci.h>
+#include <unistd.h>
 
 namespace BLEPP
 {
@@ -79,8 +80,8 @@ namespace BLEPP
 		bool uuid_32_bit_complete=0;
 		bool uuid_128_bit_complete=0;
 		
-		boost::optional<Name>  local_name;
-		boost::optional<Flags> flags;
+		std::optional<Name>  local_name;
+		std::optional<Flags> flags;
 
 		std::vector<std::vector<uint8_t>> manufacturer_specific_data;
 		std::vector<std::vector<uint8_t>> service_data;

--- a/examples/lescan.cc
+++ b/examples/lescan.cc
@@ -9,7 +9,7 @@
 #include <array>
 #include <iomanip>
 #include <vector>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <signal.h>
 


### PR DESCRIPTION
Fixes https://github.com/edrosten/libblepp/issues/8 by removing boost::optional in favour of std::optional. Changes the standard from 11 to 17